### PR TITLE
json-payload uses jsexpr->bytes; status line tolerates absent Reason-Phrase and separating space

### DIFF
--- a/http-easy/http-easy/private/payload.rkt
+++ b/http-easy/http-easy/private/payload.rkt
@@ -36,12 +36,14 @@
     (lambda (in out)
       (gzip-through-ports in out #f (current-seconds))))))
 
-(define/contract (json-payload v)
+(define/contract (json-payload v #:chunked? [chunked? #f])
   (-> jsexpr? payload-procedure/c)
   (lambda (hs)
     (values
      (hash-set hs 'content-type #"application/json; charset=utf-8")
-     (~>> v write-json))))
+     (if chunked?
+       (~>> v write-json)
+       (jsexpr->bytes v)))))
 
 (define/contract ((pure-payload v) hs)
   (-> (or/c bytes? string? input-port?) payload-procedure/c)

--- a/http-easy/http-easy/private/response.rkt
+++ b/http-easy/http-easy/private/response.rkt
@@ -58,10 +58,11 @@
 (define/contract (make-response status headers output history closer)
   (-> bytes? (listof bytes?) input-port? (listof response?) response-closer/c response?)
   (match status
-    [(regexp #rx"^HTTP/(...) ([1-9][0-9][0-9]) (.*)$"
+    [(regexp #rx"^HTTP/(...) ([1-9][0-9][0-9])( (.*))?$"
              (list status-line
                    http-version
                    (app bytes->number status-code)
+                   _
                    status-message))
      (define-values (retaining-output retain)
        (make-retaining-input-port output))


### PR DESCRIPTION
I encountered an HTTP server in the wild that:

1. Did not support `Transfer-encoding: chunked` for requests
2. Emitted status lines of the form `HTTP/1.1 200` (no `OK`)

Apparently, support for chunked requests is inconsistent, and given that json payloads are typically small, it seems reasonable to me to have the default behavior of `json-payload` be to immediately convert the jsexpr to a byte string. Opting into previous behavior is easy with `#:data (json-payload v #:chunked? #t)`.

The status line issue violates https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1 but it seems like a harmless input to accept. 